### PR TITLE
More precise nonce

### DIFF
--- a/cexapi.py
+++ b/cexapi.py
@@ -25,7 +25,7 @@ class api:
 
  ##get timestamp as nonce
  def __nonce(self):
-  self.__nonce_v = str(time.time()).split('.')[0] 
+  self.__nonce_v = '{:.10f}'.format(time.time()*1000).split('.')[0]
  
  ##generate segnature
  def __signature(self):


### PR DESCRIPTION
The python time.time() only gives you precision to the second. This
means that api calls made within the same second were failing. This
change will make the nonce the current time in miliseconds, fixing the
issue.
